### PR TITLE
安全优化：启用加密 DNS（DoH），禁用 DNS 回退，增加 GEOIP 分流，关闭 MITM

### DIFF
--- a/docs/03.shadowsocks_tiny.conf
+++ b/docs/03.shadowsocks_tiny.conf
@@ -1,19 +1,28 @@
 [General]
 bypass-system = true
+# 保留本地网段跳过代理
 skip-proxy = 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12, localhost, *.local, captive.apple.com
 tun-excluded-routes = 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.0.0/24, 192.0.2.0/24, 192.88.99.0/24, 192.168.0.0/16, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 255.255.255.255/32, 239.255.255.250/32
-dns-server = system
+
+# 安全起见：使用加密 DNS（DoH），替换为你信任的服务；若坚持用 system，可保留 system
+dns-server = https://cloudflare-dns.com/dns-query, https://dns.google/dns-query, https://dns.alidns.com/dns-query
+
+# IPv6 保持禁用（除非你确实需要并已准备好 IPv6 规则）
 ipv6 = false
 prefer-ipv6 = false
+
+# DNS 回退策略：避免在本地 DNS 失败时把查询通过代理走出
 dns-fallback-system = false
 dns-direct-system = false
+dns-direct-fallback-proxy = false
 icmp-auto-reply = true
 always-reject-url-rewrite = false
 private-ip-answer = true
-dns-direct-fallback-proxy = true
 
 [Rule]
-FINAL,DIRECT
+# 启用 GeoIP 国别直连
+GEOIP,CN,DIRECT
+FINAL,PROXY
 
 [MITM]
 enable = false


### PR DESCRIPTION
# 安全优化：启用加密 DNS（DoH），禁用 DNS 回退，增加 GEOIP 分流，关闭 MITM

## 背景说明
当前配置文件默认使用 **system DNS**，且允许在解析失败时回退到系统或代理 DNS。  
这可能导致以下问题：
1. DNS 查询可能被运营商或中间人劫持（存在泄露或污染风险）；  
2. 海外流量默认直连（`FINAL,DIRECT`），无法保证隐私加密；  
3. 启用 MITM 解密可能造成安全隐患；  
4. 未强制分流，国内/国外解析结果可能混乱。

本次修改旨在增强隐私与稳定性，并统一分流逻辑。

## 修改内容

### 1) 启用加密 DNS（DoH）
将原有的 `dns-server = system` 改为使用 **加密 DNS（DoH）**：
```ini
dns-server = https://cloudflare-dns.com/dns-query, https://dns.google/dns-query, https://dns.alidns.com/dns-query
```
- 前两者为国际主流隐私 DNS；
- 最后添加阿里 DoH 作为中国网络环境下的备用通道。

### 2) 禁用 DNS 回退机制
防止系统或代理在 DNS 失败时回退到明文或代理 DNS，杜绝信息外泄：
```ini
dns-fallback-system = false
dns-direct-system = false
dns-direct-fallback-proxy = false
```

### 3) 保留本地网段与路由排除
继续保留内网及私有地址段跳过代理，避免影响局域网与 Docker 等内部通信。
```ini
skip-proxy = 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12, localhost, *.local, captive.apple.com
tun-excluded-routes = 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.0.0/24, 192.0.2.0/24, 192.88.99.0/24, 192.168.0.0/16, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 255.255.255.255/32, 239.255.255.250/32
```

### 4) 添加 GEOIP 分流规则
实现 **国内直连、海外代理** 的自动分流逻辑：
```ini
[Rule]
GEOIP,CN,DIRECT
FINAL,Proxy
```

### 5) 明确关闭 HTTPS 解密（MITM）
防止 Shadowrocket 截获 HTTPS 流量，保障隐私安全：
```ini
[MITM]
enable = false
```

## 修改前后对比

| 项目 | 修改前 | 修改后 |
|------|---------|---------|
| DNS 查询 | 使用系统 DNS，明文 | 使用 DoH，全程加密 |
| DNS 回退 | 允许系统/代理回退 | 全部禁用 |
| 海外流量 | 默认直连（不安全） | 默认代理（安全） |
| 国内分流 | 无明确逻辑 | GEOIP 自动识别 |
| HTTPS 解密 | 可能启用 | 明确关闭 |
| 内网访问 | 可能被代理 | 保持直连 |

## 验证步骤
1. 在 Shadowrocket 中启用该配置；
2. 访问 https://1.1.1.1/help，确认 “Using DNS over HTTPS (DoH)” 为 **Yes**；
3. 访问国内网站（微信、Bilibili、淘宝等），日志应显示：
   ```
   Matched rule: GEOIP,CN,DIRECT
   ```
4. 访问国外网站（Google、YouTube、Twitter 等），日志应显示：
   ```
   Matched rule: FINAL,Proxy
   ```
5. 测试内网服务（如局域网打印机、Docker 容器、AirPlay）应仍能正常通信。

## 回滚方案
若发现无法解析或网络受阻，可快速回滚：
- 暂时改回：
  ```ini
  dns-server = system
  ```
- 或临时启用系统回退：
  ```ini
  dns-fallback-system = true
  ```

## 维护者建议
- 该配置适用于追求 **隐私、安全与稳定分流** 的用户；
- 若使用环境在中国大陆，可根据可用性调整 DoH 顺序；
- 若网络存在强制 DNS 劫持，可考虑将首选 DoH 改为境内的公共加密 DNS（例如阿里或腾讯）。

---